### PR TITLE
Add podman-compose config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # codextest
+
+This repository contains a minimal Next.js to-do application located in the
+`todo-app` directory. A `podman-compose.yml` file is provided so you can start a
+development environment without installing Node or PostgreSQL locally.
+
+Run the following command to build the local container image and launch the
+stack:
+
+```bash
+podman-compose up --build
+```
+
+The compose file builds the Node image from the repository, so it works even if
+no registry is configured.

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: todo
+      POSTGRES_PASSWORD: todo
+      POSTGRES_DB: todo
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+  app:
+    build: ./todo-app
+    working_dir: /app
+    volumes:
+      - ./todo-app:/app:Z
+    environment:
+      DATABASE_URL: postgres://todo:todo@db:5432/todo
+    command: npm run dev
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+volumes:
+  pgdata:

--- a/todo-app/Dockerfile
+++ b/todo-app/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+CMD ["npm", "run", "dev"]

--- a/todo-app/README.md
+++ b/todo-app/README.md
@@ -4,6 +4,24 @@ This is a minimal Next.js to-do list example with drag and drop and PostgreSQL p
 
 ## Setup
 
+### Using Podman Compose
+
+If you have Podman and `podman-compose` installed you can bring up a ready-to-use
+development environment without installing Node or PostgreSQL locally:
+
+```bash
+podman-compose -f ../podman-compose.yml up
+```
+
+Add the `--build` flag on the first run to build the local Node image. This
+makes the setup work even if you don't have a registry configured.
+
+This starts both PostgreSQL and the Next.js dev server. The application will be
+available on [http://localhost:3000](http://localhost:3000). The database data
+is persisted in the `pgdata` volume.
+
+### Manual Setup
+
 1. Install dependencies:
    ```bash
    npm install


### PR DESCRIPTION
## Summary
- add Dockerfile for Node-based dev server
- allow podman-compose to build the app image
- document podman-compose workflow

## Testing
- `podman-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cefc4001c832ba5a75ef1a4a5da60